### PR TITLE
feat: Context Menu

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
   "packageManager": "pnpm@8.6.5",
   "dependencies": {
     "lucide-svelte": "^0.290.0",
-    "sortablejs": "^1.15.0"
+    "sortablejs": "^1.15.0",
+    "svelte-contextmenu": "^1.0.2"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,9 @@ dependencies:
   sortablejs:
     specifier: ^1.15.0
     version: 1.15.0
+  svelte-contextmenu:
+    specifier: ^1.0.2
+    version: 1.0.2
 
 devDependencies:
   '@tsconfig/svelte':
@@ -1869,6 +1872,10 @@ packages:
     dependencies:
       has-flag: 4.0.0
     dev: true
+
+  /svelte-contextmenu@1.0.2:
+    resolution: {integrity: sha512-S4mSFnafXhhrDMvP45W7+8+LH45tGFyigMJav4bpc19rD2L3awMJLHg5PY9EAvF8OU9lIMiaUMxEgFlTK/kqPQ==}
+    dev: false
 
   /svelte-preprocess@5.0.4(svelte@4.2.2)(typescript@4.7.4):
     resolution: {integrity: sha512-ABia2QegosxOGsVlsSBJvoWeXy1wUKSfF7SWJdTjLAbx/Y3SrVevvvbFNQqrSJw89+lNSsM58SipmZJ5SRi5iw==}

--- a/src/util/vault.ts
+++ b/src/util/vault.ts
@@ -1,0 +1,17 @@
+import type { App } from 'obsidian';
+
+export const getAbstractFile = (app: App, path: string) => {
+  return app.vault.getAbstractFileByPath(path);
+};
+
+export const trashVaultFile = async (app: App, path: string, system: boolean) => {
+  const file = getAbstractFile(app, path);
+  if (!file) return;
+  return await app.vault.trash(file, system);
+};
+
+export const deleteVaultFile = async (app: App, path: string) => {
+  const file = getAbstractFile(app, path);
+  if (!file) return;
+  return await app.vault.delete(file);
+};

--- a/styles.css
+++ b/styles.css
@@ -25,6 +25,10 @@ ul.vertical-tabs-view-list {
   text-overflow: ellipsis;
 }
 
+.vertical-tabs-view-list li.vertical-tabs-view-list-item:hover {
+  background-color: var(--background-modifier-hover);
+}
+
 .vertical-tabs-view-list-item-ghost {
   opacity: 0.3;
 }
@@ -132,4 +136,14 @@ ul.vertical-tabs-view-list {
   display: flex;
   justify-content: end;
   margin-top: 1em;
+}
+
+/* context menu */
+button.context-menu-item.vertical-tabs-view-context-menu-item-custom {
+  display: flex !important;
+  align-items: center;
+  justify-content: flex-start;
+}
+button.context-menu-item.vertical-tabs-view-context-menu-item-custom span {
+  padding-left: 0.25rem;
 }


### PR DESCRIPTION
#44 
Activate by right-click on PC, touch-hold on mobile

- Close tab
- Close others
- Close to the top
- Close to the bottom
- Pin
- Unpin
- Trash System
- Trash Local
- Delete file

It does work on mobile, but due to the internal specifications of the library being used, the menu may fail to close in some cases (like after swiping). It is likely unstable.

I will merge for now, but a dedicated menu (drawer?) may be needed for mobile.