### PR TITLE
#70 Standardise icon sizes & reduce tab row min height

### DIFF
--- a/src/components/Tabs.svelte
+++ b/src/components/Tabs.svelte
@@ -380,7 +380,7 @@
             class="vertical-tabs-view-list-item-close-btn vertical-tabs-view-list-item-icon"
             on:click={(e) => handleClickClose(e, leaf)}
           >
-            <X size={18} strokeWidth={2} />
+            <X />
           </div>
         {/if}
         {#if plugin.settings.showTabIcon}
@@ -399,14 +399,14 @@
             class="vertical-tabs-view-list-item-icon vertical-tabs-view-list-item-pin-btn vertical-tabs-view-list-item-pin-btn-pin"
             on:click={(e) => handleClickPin(e, leaf)}
           >
-            <Pin size={20} />
+            <Pin />
           </div>
         {:else if plugin.settings.showPinnedIcon && leaf.pinned}
           <div
             class="vertical-tabs-view-list-item-icon vertical-tabs-view-list-item-icon-pinned vertical-tabs-view-list-item-pin-btn vertical-tabs-view-list-item-pin-btn-pin"
             on:click={(e) => handleClickPinOff(e, leaf)}
           >
-            <Pin size={20} />
+            <Pin />
           </div>
         {/if}
       </div>

--- a/styles.css
+++ b/styles.css
@@ -21,7 +21,7 @@ ul.vertical-tabs-view-list {
   font-weight: var(--tab-font-weight);
   padding: 2px 0 2px 2px;
   width: 100%;
-  min-height: 2.5rem;
+  min-height: 2.5em;
   border-radius: var(--tab-radius);
   overflow: hidden;
   white-space: nowrap;
@@ -76,7 +76,7 @@ ul.vertical-tabs-view-list {
 .vertical-tabs-view-list li .vertical-tabs-view-list-item-right-container {
   flex-shrink: 0;
 }
-
+/* icons */
 .vertical-tabs-view-list li .vertical-tabs-view-list-item-icon {
   color: var(--tab-text-color);
   padding-top: 0.25em;
@@ -85,15 +85,11 @@ ul.vertical-tabs-view-list {
 .vertical-tabs-view-list li .vertical-tabs-view-list-item-tab-icon {
   margin: 0 0.25em;
   min-width: var(--icon-s);
-  --icon-size: var(--icon-s);
-  --icon-stroke: var(--icon-s-stroke-width);
 }
 
 .vertical-tabs-view-list li .vertical-tabs-view-list-item-close-btn,
 .vertical-tabs-view-list li .vertical-tabs-view-list-item-pin-btn {
   cursor: pointer;
-  --icon-size: var(--icon-l);
-  --icon-stroke: var(--icon-l-stroke-width);
 }
 
 .vertical-tabs-view-list li .vertical-tabs-view-list-item-close-btn:hover,
@@ -108,7 +104,13 @@ ul.vertical-tabs-view-list {
 
 .vertical-tabs-view-list li .vertical-tabs-view-list-item-pin-btn {
   margin-right: 0.5em;
-  margin-top: 0.5em;
+}
+.vertical-tabs-view-list-item-close-btn > svg,
+.vertical-tabs-view-list-item-pin-btn > svg, 
+.vertical-tabs-view-list-item-tab-icon > svg {
+    width: 1.5em;
+    height: 1.5em;
+    stroke-width: var(--icon-s-stroke-width);
 }
 
 .vertical-tabs-view-list li .vertical-tabs-view-list-item-name-container {


### PR DESCRIPTION
Not sure if you accept PRs, but here's a few changes I made locally with intentions aligned to #70, in case they are helpful:

* Decrease minimum row height
* Standardise margins & sizes for all icons to min row height
* Avoid pin increasing line size
* Move all size setting for icons to styles.css for ease of config & potential settings additions

Happy to make any changes if you have comments.

Particularly happy to revert to the existing size discrepancy between the buttons & the tab icon if you'd prefer (using --icon-l & --icon-s respectively) - on main the size of the parent div is not pulled through to the actual svg icons, so the pin is larger than expected (20x20 vs 18x18).